### PR TITLE
Made work on latest nightly, added IPv4 support, changed some interfaces.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.0.1"
 authors = ["Vanhala Antti <antti.vanhala@aalto.fi>"]
 license = "MIT"
 build = "build.rs"
+
+[dependencies]
+libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,8 @@
-#![feature(env, fs, io, path, process)]
-
 use std::env;
 use std::path::Path;
 use std::process::Command;
 use std::fs::File;
 use std::io::Write;
-
 
 fn main() {
 	let src_dir_str = env::var_os("CARGO_MANIFEST_DIR").unwrap();

--- a/src/c_interop.rs
+++ b/src/c_interop.rs
@@ -1,5 +1,4 @@
-use libc::types::os::common::bsd44::in6_addr;
-use libc::{c_int, c_short};
+use libc::{c_int, c_ulong, c_short, in6_addr};
 
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 

--- a/src/c_interop.rs
+++ b/src/c_interop.rs
@@ -5,25 +5,25 @@ include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
 #[repr(C)]
 pub struct in_ifreq {
-	pub ifr_name: [u8; IFNAMSIZ],
-	pub ifr_addr: sockaddr_in,
+	  pub ifr_name: [u8; IFNAMSIZ],
+	  pub ifr_addr: sockaddr_in,
 }
 
 #[repr(C)]
 pub struct in6_ifreq {
-	pub ifr6_addr: in6_addr,
-	pub ifr6_prefixlen: u32,
-	pub ifr6_ifindex: c_int
+	  pub ifr6_addr: in6_addr,
+	  pub ifr6_prefixlen: u32,
+	  pub ifr6_ifindex: c_int
 }
 
 #[repr(C)]
 pub struct ioctl_flags_data {
-	pub ifr_name: [u8; IFNAMSIZ],
-	pub ifr_flags: c_short
+	  pub ifr_name: [u8; IFNAMSIZ],
+	  pub ifr_flags: c_short
 }
 
 #[repr(C)]
 pub struct ioctl_ifindex_data {
-	pub ifr_name: [u8; IFNAMSIZ],
-	pub ifr_ifindex: c_int
+	  pub ifr_name: [u8; IFNAMSIZ],
+	  pub ifr_ifindex: c_int
 }

--- a/src/c_interop.rs
+++ b/src/c_interop.rs
@@ -1,7 +1,13 @@
-use libc::{c_int, c_ulong, c_short, in6_addr};
+extern crate libc;
+use libc::{c_int, c_ulong, c_short, sockaddr_in, in6_addr};
 
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
+#[repr(C)]
+pub struct in_ifreq {
+	pub ifr_name: [u8; IFNAMSIZ],
+	pub ifr_addr: sockaddr_in,
+}
 
 #[repr(C)]
 pub struct in6_ifreq {

--- a/src/constants.c
+++ b/src/constants.c
@@ -6,15 +6,16 @@
 #define RUST_CONST(name, type, printf_type) printf("pub const " #name ": " #type " = " printf_type ";\n", name);
 
 int main() {
-	RUST_CONST(TUNSETIFF, c_int, "%lu")
-	RUST_CONST(SIOCSIFADDR, c_int, "%d")
-	RUST_CONST(SIOCGIFINDEX, c_int, "%d")
-	RUST_CONST(SIOCGIFFLAGS, c_int, "%d")
-	RUST_CONST(SIOCSIFFLAGS, c_int, "%d")
+	RUST_CONST(TUNSETIFF, c_ulong, "%lu")
+	RUST_CONST(SIOCSIFADDR, c_ulong, "%d")
+	RUST_CONST(SIOCGIFINDEX, c_ulong, "%d")
+	RUST_CONST(SIOCGIFFLAGS, c_ulong, "%d")
+	RUST_CONST(SIOCSIFFLAGS, c_ulong, "%d")
 
 	RUST_CONST(IFF_TUN, c_short, "%d")
 	RUST_CONST(IFF_TAP, c_short, "%d")
-	RUST_CONST(IFF_UP, c_short, "%d")
+  RUST_CONST(IFF_NO_PI, c_short, "%d")
+  RUST_CONST(IFF_UP, c_short, "%d")
 	RUST_CONST(IFF_RUNNING, c_short, "%d")
 
 	RUST_CONST(IFNAMSIZ, usize, "%d")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate libc;
 
 pub use tuntap::TunTap;
 pub use tuntap::TunTapType::{Tun, Tap};
+pub use tuntap::IpType::{Ipv4, Ipv6};
 
 mod tuntap;
 mod c_interop;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(collections, core, fs, hash, io, libc, path, std_misc)]
+#![feature(libc, clone_from_slice)]
 
 extern crate libc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(libc, clone_from_slice)]
-
 extern crate libc;
 
 pub use tuntap::TunTap;

--- a/src/tuntap.rs
+++ b/src/tuntap.rs
@@ -81,7 +81,7 @@ impl TunTap {
 		let mut req = ioctl_flags_data {
 			ifr_name: {
 				let mut buffer = [0u8; IFNAMSIZ];
-				buffer.clone_from_slice(name_slice);
+				buffer[..name_slice.len()].clone_from_slice(name_slice);
 				buffer
 			},
 			ifr_flags: match typ {

--- a/src/tuntap.rs
+++ b/src/tuntap.rs
@@ -85,8 +85,8 @@ impl TunTap {
 				buffer
 			},
 			ifr_flags: match typ {
-				TunTapType::Tun => IFF_TUN,
-				TunTapType::Tap => IFF_TAP
+				TunTapType::Tun => IFF_TUN | IFF_NO_PI,
+				TunTapType::Tap => IFF_TAP | IFF_NO_PI
 			}
 		};
 

--- a/src/tuntap.rs
+++ b/src/tuntap.rs
@@ -7,7 +7,8 @@ use std::io;
 use std::mem;
 use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
-use libc::{c_int, c_char, c_void, AF_INET, AF_INET6, SOCK_DGRAM, socket, ioctl, close, in_addr, in6_addr, sockaddr_in, sa_family_t};
+use libc::{c_int, c_char, c_void, AF_INET, AF_INET6, SOCK_DGRAM,
+           socket, ioctl, close, in_addr, in6_addr,sockaddr_in, sa_family_t};
 use c_interop::*;
 
 const DEVICE_PATH: &'static str = "/dev/net/tun";
@@ -23,8 +24,8 @@ extern {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum TunTapType {
-	Tun,
-	Tap
+	  Tun,
+	  Tap
 }
 
 pub enum IpType {
@@ -33,30 +34,30 @@ pub enum IpType {
 }
 
 pub struct TunTap {
-	pub file: File,
-	sock: c_int,
-  ip_type: IpType,
-	if_name: [u8; IFNAMSIZ],
-	if_index: c_int
+	  pub file: File,
+	  sock: c_int,
+    ip_type: IpType,
+	  if_name: [u8; IFNAMSIZ],
+	  if_index: c_int
 }
 
 impl Drop for TunTap {
-	fn drop(&mut self) {
-		unsafe { close(self.sock) };
-	}
+	  fn drop(&mut self) {
+		    unsafe { close(self.sock) };
+	  }
 }
 
 impl fmt::Debug for TunTap {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "Tun({:?})", self.get_name())
-	}
+	  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		    write!(f, "Tun({:?})", self.get_name())
+	  }
 }
 
 
 impl TunTap {
-	pub fn create(typ: TunTapType, ip_type: IpType) -> TunTap {
-		TunTap::create_named(typ, ip_type, &CString::new("").unwrap())
-	}
+	  pub fn create(typ: TunTapType, ip_type: IpType) -> TunTap {
+		    TunTap::create_named(typ, ip_type, &CString::new("").unwrap())
+	  }
 
     pub fn create_named_from_address(typ: TunTapType,
                                      name: &CString, ip: &CString) -> TunTap {
@@ -67,122 +68,119 @@ impl TunTap {
                 Err(_) => panic!("Ip address was neither version 4 or version 6")
             }
         };
-        let mut tt = TunTap::create_named(typ, ip_type, name);
+        let tt = TunTap::create_named(typ, ip_type, name);
         tt.add_address(ip);
         tt
     }
 
-	pub fn create_named(typ: TunTapType, ip_type: IpType, name: &CString) ->
-        TunTap {
-		let (file, if_name) = TunTap::create_if(typ, name);
-		let (sock, if_index) = TunTap::create_socket(&ip_type, if_name);
+	  pub fn create_named(typ: TunTapType, ip_type: IpType, name: &CString) -> TunTap {
+		    let (file, if_name) = TunTap::create_if(typ, name);
+		    let (sock, if_index) = TunTap::create_socket(&ip_type, if_name);
 
-		TunTap {
-			file: file,
-			sock: sock,
-      ip_type: ip_type,
-			if_name: if_name,
-			if_index: if_index
-		}
-	}
+		    TunTap {
+			      file: file,
+			      sock: sock,
+            ip_type: ip_type,
+			      if_name: if_name,
+			      if_index: if_index
+		    }
+	  }
 
-	fn create_if(typ: TunTapType, name: &CString) -> (File, [u8; IFNAMSIZ]) {
-		let name_slice = name.as_bytes_with_nul();
-		if name_slice.len() > IFNAMSIZ {
-			panic!("Interface name too long, max length is {}", IFNAMSIZ - 1);
-		}
+	  fn create_if(typ: TunTapType, name: &CString) -> (File, [u8; IFNAMSIZ]) {
+		    let name_slice = name.as_bytes_with_nul();
+		    if name_slice.len() > IFNAMSIZ {
+			      panic!("Interface name too long, max length is {}", IFNAMSIZ - 1);
+		    }
 
-		let path = Path::new(DEVICE_PATH);
-		let file = match OpenOptions::new().read(true).write(true).open(&path) {
-			Err(why) => panic!("Couldn't open tun device '{}': {:?}",
-                         path.display(), why),
-			Ok(file) => file,
-		};
+		    let path = Path::new(DEVICE_PATH);
+		    let file = match OpenOptions::new().read(true).write(true).open(&path) {
+			      Err(why) => panic!("Couldn't open tun device '{}': {:?}",
+                               path.display(), why),
+			      Ok(file) => file,
+		    };
 
-		let mut req = ioctl_flags_data {
-			ifr_name: {
-				let mut buffer = [0u8; IFNAMSIZ];
-				buffer[..name_slice.len()].clone_from_slice(name_slice);
-				buffer
-			},
-			ifr_flags: match typ {
-				TunTapType::Tun => IFF_TUN | IFF_NO_PI,
-				TunTapType::Tap => IFF_TAP | IFF_NO_PI
-			}
-		};
+		    let mut req = ioctl_flags_data {
+			      ifr_name: {
+				        let mut buffer = [0u8; IFNAMSIZ];
+				        buffer[..name_slice.len()].clone_from_slice(name_slice);
+				        buffer
+			      },
+			      ifr_flags: match typ {
+				        TunTapType::Tun => IFF_TUN | IFF_NO_PI,
+				        TunTapType::Tap => IFF_TAP | IFF_NO_PI
+			      }
+		    };
 
-		let res = unsafe { ioctl(file.as_raw_fd(), TUNSETIFF, &mut req) };
-		if res < 0 {
-			panic!("{}", io::Error::last_os_error());
-		}
+		    let res = unsafe { ioctl(file.as_raw_fd(), TUNSETIFF, &mut req) };
+		    if res < 0 {
+			      panic!("{}", io::Error::last_os_error());
+		    }
 
-		(file, req.ifr_name)
-	}
+		    (file, req.ifr_name)
+	  }
 
-	fn create_socket(ip_type: &IpType, if_name: [u8; IFNAMSIZ]) ->
-        (c_int, c_int) {
-    let sock_type = match ip_type {
-        &IpType::Ipv4 => AF_INET,
-        &IpType::Ipv6 => AF_INET6
-    };
-		let sock = unsafe { socket(sock_type, SOCK_DGRAM, 0) };
-		if sock < 0 {
-			panic!("{}", io::Error::last_os_error());
-		}
+	  fn create_socket(ip_type: &IpType, if_name: [u8; IFNAMSIZ]) -> (c_int, c_int) {
+        let sock_type = match ip_type {
+            &IpType::Ipv4 => AF_INET,
+            &IpType::Ipv6 => AF_INET6
+        };
+		    let sock = unsafe { socket(sock_type, SOCK_DGRAM, 0) };
+		    if sock < 0 {
+			      panic!("{}", io::Error::last_os_error());
+		    }
 
-		let mut req = ioctl_ifindex_data {
-			ifr_name: if_name,
-			ifr_ifindex: -1
-		};
+		    let mut req = ioctl_ifindex_data {
+			      ifr_name: if_name,
+			      ifr_ifindex: -1
+		    };
 
-		let res = unsafe { ioctl(sock, SIOCGIFINDEX, &mut req) };
-		if res < 0 {
-			let err = io::Error::last_os_error();
-			unsafe { close(sock) };
-			panic!("{}", err);
-		}
+		    let res = unsafe { ioctl(sock, SIOCGIFINDEX, &mut req) };
+		    if res < 0 {
+			      let err = io::Error::last_os_error();
+			      unsafe { close(sock) };
+			      panic!("{}", err);
+		    }
 
-		(sock, req.ifr_ifindex)
-	}
+		    (sock, req.ifr_ifindex)
+	  }
 
-	pub fn get_name(&self) -> CString {
-    let mut it = self.if_name.iter();
-		let nul_pos = match it.position(|x| *x == 0) {
-			Some(p) => p,
-			None => panic!("Device name should be null-terminated")
-		};
+	  pub fn get_name(&self) -> CString {
+        let mut it = self.if_name.iter();
+		    let nul_pos = match it.position(|x| *x == 0) {
+			      Some(p) => p,
+			      None => panic!("Device name should be null-terminated")
+		    };
 
-	  CString::new(&self.if_name[..nul_pos]).unwrap()
-	}
+	      CString::new(&self.if_name[..nul_pos]).unwrap()
+	  }
 
-	pub fn up(&self) {
-		let mut req = ioctl_flags_data {
-			ifr_name: self.if_name,
-			ifr_flags: 0
-		};
+	  pub fn up(&self) {
+		    let mut req = ioctl_flags_data {
+			      ifr_name: self.if_name,
+			      ifr_flags: 0
+		    };
 
 
-		let res = unsafe { ioctl(self.sock, SIOCGIFFLAGS, &mut req) };
-		if res < 0 {
-			panic!("{}", io::Error::last_os_error());
-		}
+		    let res = unsafe { ioctl(self.sock, SIOCGIFFLAGS, &mut req) };
+		    if res < 0 {
+			      panic!("{}", io::Error::last_os_error());
+		    }
 
-		if req.ifr_flags & IFF_UP & IFF_RUNNING != 0 {
-			// Already up
-			return;
-		}
+		    if req.ifr_flags & IFF_UP & IFF_RUNNING != 0 {
+			      // Already up
+			      return;
+		    }
 
-		req.ifr_flags |= IFF_UP | IFF_RUNNING;
+		    req.ifr_flags |= IFF_UP | IFF_RUNNING;
 
-		let res = unsafe { ioctl(self.sock, SIOCSIFFLAGS, &mut req) };
-		if res < 0 {
-			panic!("{}", io::Error::last_os_error());
-		}
-	}
+		    let res = unsafe { ioctl(self.sock, SIOCSIFFLAGS, &mut req) };
+		    if res < 0 {
+			      panic!("{}", io::Error::last_os_error());
+		    }
+	  }
 
 
-    fn get_addr<T>(ip: &CString, addr_type: i32, addr: &mut T) ->
-        Result<(), &'static str> {
+    fn get_addr<T>(ip: &CString, addr_type: i32, addr: &mut T) -> Result<(), &'static str> {
         let addr_ptr = addr as *mut _ as *mut c_void;
         match unsafe { inet_pton(addr_type, ip.as_ptr(), addr_ptr) } {
             1 => Ok(()),
@@ -247,14 +245,14 @@ impl TunTap {
         }
     }
 
-	pub fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-		assert!(buffer.len() >= MTU_SIZE);
+	  pub fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+		    assert!(buffer.len() >= MTU_SIZE);
 
-		let len = try!(self.file.read(buffer));
-		Ok(len)
-	}
+		    let len = try!(self.file.read(buffer));
+		    Ok(len)
+	  }
 
-	pub fn write(&mut self, data: &[u8]) -> io::Result<()> {
-		self.file.write_all(data)
-	}
+	  pub fn write(&mut self, data: &[u8]) -> io::Result<()> {
+		    self.file.write_all(data)
+	  }
 }

--- a/src/tuntap.rs
+++ b/src/tuntap.rs
@@ -189,11 +189,11 @@ impl TunTap {
     }		
 	}
 
-	pub fn read<'a>(&mut self, buffer: &'a mut [u8]) -> io::Result<&'a [u8]> {
+	pub fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
 		assert!(buffer.len() >= MTU_SIZE);
 
 		let len = try!(self.file.read(buffer));
-		Ok(&buffer[..len])
+		Ok(len)
 	}
 
 	pub fn write(&mut self, data: &[u8]) -> io::Result<()> {


### PR DESCRIPTION
Hiya,

I wanted to use this library and discovered it needed some work to get it running on current Rust. So I fixed the issues, and as I used the lib, I made some modifications as well. Put them all in a big pull request, as it's a bit of a hassle to detangle some things. Tell me if this is a problem.

In no particular order:
- Added IPv4 support: this means that when making a TunTap, we should specify if we want IPv4 or IPv6.
- Interface functions take &str, instead of &CString.
- add_address takes &str instead of &[u8].
- added create_named_from_address, which brings up a tun/tap device and adds the address in one go, and tries to deduce if we want IPv4 or IPv6 based on the address we supply.
- Indented code with 4-space style, as it seems to have become the default in Rust-land.

Let me know what you think :)
